### PR TITLE
doc: adds `go get` to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You need [glide](http://glide.sh/) for dependencies.
 
 ```bash
 glide install
+go get
 ```
 
 ## Build


### PR DESCRIPTION
I have absolutely no experience with go, but I needed to use `go get` to install dependencies global in `$GOPATH/go/src` before the build worked. Maybe there's a better way to do this?